### PR TITLE
chore: set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single Next.js 16 (App Router, Turbopack, React Compiler) personal portfolio website. There is no database, no docker-compose, and no monorepo — just one app at the repo root. Package manager is **Bun**.
+
+### Services
+
+| Service | Command | Port | Notes |
+| --- | --- | --- | --- |
+| Next.js dev server | `bun run dev` | 3000 | The entire product (frontend + blog + `/api/*` routes). |
+
+### Non-obvious notes
+
+- **Bun is the package manager** (`bun.lock`). The startup update script installs Bun to `~/.bun/bin` and adds it to `PATH` via `~/.bashrc`. If `bun` is not found in a fresh shell, run `export PATH="$HOME/.bun/bin:$PATH"`.
+- **Contentlayer must be generated before type-checking/building.** `bun install` runs `contentlayer2 postinstall`, but a full content build (`bunx contentlayer2 build`, aka `bun run build:content`) generates `.contentlayer/generated`, which `/api/feed` and blog pages import. Run it before `bunx tsc --noEmit` or `next build`. The dev server (`bun run dev`) builds content automatically.
+- **Lint/format uses Biome**, not ESLint: `bun run lint` (lint), `bun run fmt` (check + autofix). CI runs `bunx biome ci .`.
+- **CI equivalent checks** (`.github/workflows/ci.yml`): `bun install --frozen-lockfile` → `bunx contentlayer2 build` → `bunx tsc --noEmit` → `bunx biome ci .`.
+- **Env vars are all optional** with graceful fallbacks. `GITHUB_STATS_TOKEN` powers the live GitHub stats widget (`/api/github`); without it the route returns empty data and logs a warning, but the app still runs fine.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Next.js 16 personal portfolio website so Cursor Cloud agents can install dependencies, run lint/type checks, and run the app.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting the Bun package manager, the Contentlayer generation requirement, Biome lint/format commands, and the optional `GITHUB_STATS_TOKEN`.
- Configures the startup update script to install Bun (idempotently) and run `bun install --frozen-lockfile`.

No application code was changed.

## Verification

- ✅ `bun install --frozen-lockfile` (406 packages, runs `contentlayer2 postinstall`)
- ✅ `bunx contentlayer2 build` (generated 4 documents)
- ✅ `bunx tsc --noEmit`
- ✅ `bunx biome ci .` (53 files, no issues)
- ✅ `bun run dev` — server ready on port 3000; `/`, `/blog`, `/api/feed`, `/api/github` all return HTTP 200

## Walkthrough

Demo of the running site: homepage hero + portfolio sections, blog listing, and opening a full blog post.

[portfolio_site_demo.mp4](https://cursor.com/agents/bc-48a273f8-67e4-40c5-8a43-5b85ffd9a407/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_site_demo.mp4)

[Homepage hero](https://cursor.com/agents/bc-48a273f8-67e4-40c5-8a43-5b85ffd9a407/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_hero.webp)
[Blog listing](https://cursor.com/agents/bc-48a273f8-67e4-40c5-8a43-5b85ffd9a407/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_listing.webp)
[Blog post](https://cursor.com/agents/bc-48a273f8-67e4-40c5-8a43-5b85ffd9a407/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48a273f8-67e4-40c5-8a43-5b85ffd9a407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48a273f8-67e4-40c5-8a43-5b85ffd9a407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

