### PR TITLE
chore: set up Mend Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,68 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:recommended",
+		"helpers:pinGitHubActionDigests"
+	],
+	"timezone": "UTC",
+	"labels": ["dependencies"],
+	"semanticCommits": "enabled",
+	"commitMessageLowerCase": "auto",
+	"schedule": ["before 6am on monday"],
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": ["before 6am on the first day of the month"]
+	},
+	"packageRules": [
+		{
+			"description": "Require dashboard approval for major dependency updates",
+			"matchUpdateTypes": ["major"],
+			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "Keep Contentlayer packages in sync",
+			"matchManagers": ["bun"],
+			"groupName": "contentlayer",
+			"matchPackageNames": ["contentlayer2", "next-contentlayer2"]
+		},
+		{
+			"description": "Group React runtime and type packages",
+			"matchManagers": ["bun"],
+			"groupName": "react",
+			"matchPackageNames": [
+				"react",
+				"react-dom",
+				"@types/react",
+				"@types/react-dom"
+			]
+		},
+		{
+			"description": "Group Tailwind CSS packages",
+			"matchManagers": ["bun"],
+			"groupName": "tailwindcss",
+			"matchPackageNames": [
+				"tailwindcss",
+				"@tailwindcss/postcss",
+				"tailwindcss-animate",
+				"tailwind-merge",
+				"tw-animate-css"
+			]
+		},
+		{
+			"description": "Group Radix UI primitives",
+			"matchManagers": ["bun"],
+			"groupName": "radix-ui",
+			"matchPackageNames": ["/^@radix-ui//"]
+		},
+		{
+			"description": "Group GitHub Actions updates",
+			"matchManagers": ["github-actions"],
+			"groupName": "github actions"
+		},
+		{
+			"description": "Group Docker base image updates",
+			"matchManagers": ["dockerfile"],
+			"groupName": "docker"
+		}
+	]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `renovate.json` configuration so [Mend Renovate](https://github.com/apps/renovate) can manage dependency updates for this Bun/Next.js portfolio site.

## Configuration highlights

- **Presets**: `config:recommended` plus `helpers:pinGitHubActionDigests` for safer GitHub Actions pinning
- **Bun**: lockfile maintenance on a monthly schedule (Renovate auto-detects `bun.lock`)
- **Grouping**: related packages are batched into single PRs (Contentlayer, React, Tailwind, Radix UI, GitHub Actions, Docker)
- **Safety**: major version bumps require approval from the Renovate dependency dashboard
- **PR titles**: semantic commit format to satisfy the existing PR title workflow

## Required follow-up (GitHub UI)

Mend Renovate runs as a GitHub App and must be installed on the repository:

1. Open https://github.com/apps/renovate
2. Click **Configure** and grant access to `Robert27/eggl.dev` (or the whole org)
3. After installation, Renovate will pick up `renovate.json` and start opening update PRs on the configured schedule

If the app was previously installed, no further action is needed beyond merging this PR.

## Test plan

- [x] `renovate.json` validates as JSON
- [ ] Merge PR
- [ ] Install/configure Mend Renovate GitHub App on the repository
- [ ] Confirm Renovate opens dependency update PRs (or posts the dependency dashboard issue)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4563-c0ef-7fe7-a5df-f6a0c1580a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4563-c0ef-7fe7-a5df-f6a0c1580a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

